### PR TITLE
Fix gcc-13 includes

### DIFF
--- a/power_overwhelming/src/adl_scope.cpp
+++ b/power_overwhelming/src/adl_scope.cpp
@@ -6,6 +6,7 @@
 #include "adl_scope.h"
 
 #include <cassert>
+#include <cstdint>
 
 #include "adl_exception.h"
 #include "amd_display_library.h"

--- a/power_overwhelming/src/event.cpp
+++ b/power_overwhelming/src/event.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <condition_variable>
 #include <mutex>
+#include <system_error>
 
 #include <errno.h>
 

--- a/power_overwhelming/src/tinkerforge_display_impl.cpp
+++ b/power_overwhelming/src/tinkerforge_display_impl.cpp
@@ -5,6 +5,8 @@
 
 #include "tinkerforge_display_impl.h"
 
+#include <stdexcept>
+
 
 /*
  * visus::power_overwhelming::detail::tinkerforge_display_impl::tinkerforge_display_impl

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -28,7 +28,7 @@ mark_as_advanced(FORCE
 
 # JSON library
 FetchContent_Declare(nlohmann_json
-    URL "https://github.com/nlohmann/json/archive/v3.11.2.tar.gz"
+    URL "https://github.com/nlohmann/json/archive/v3.11.3.tar.gz"
 )
 FetchContent_MakeAvailable(nlohmann_json)
 mark_as_advanced(FORCE


### PR DESCRIPTION
- Add missing includes to build with gcc-13
- Update nlohmann_json to get rid of CMake version warning.